### PR TITLE
throw exception if the address range is not available

### DIFF
--- a/ida_load_image.cc
+++ b/ida_load_image.cc
@@ -31,7 +31,12 @@ ida_load_image::ida_load_image(ida_arch *a) : LoadImage("ida_progam") {
 }
 
 void ida_load_image::loadFill(uint1 *ptr, int4 size, const Address &inaddr) {
-   get_bytes(ptr, size, inaddr.getOffset());
+    if (!get_bytes(ptr, size, inaddr.getOffset())) {
+        ostringstream errmsg;
+        errmsg << "Unable to load " << dec << size << " bytes at " << inaddr.getShortcut();
+        inaddr.printRaw(errmsg);
+        throw DataUnavailError(errmsg.str());
+    }
 }
 
 string ida_load_image::getArchType(void) const {

--- a/run.cc
+++ b/run.cc
@@ -270,7 +270,14 @@ int do_decompile(uint64_t start_ea, uint64_t end_ea, Function **result) {
 
       arch->allacts.getCurrent()->reset(*fd);
 
-      res = arch->allacts.getCurrent()->perform(*fd);
+      try {
+          res = arch->allacts.getCurrent()->perform(*fd);
+      }
+      catch (DataUnavailError &err) {
+          msg("Could not decompile function at 0x%x\n - %s", start_ea, err.explain.c_str());
+          check_err_stream();
+          return -1;
+      }
 
       if (res < 0) {
          ostringstream os;


### PR DESCRIPTION
If a function is in special segment, get_bytes might fail, so I added code that throws DataUnavailError as loadimage.cc does.