### PR TITLE
Add support for Xbox360 executables

### DIFF
--- a/plugin.cc
+++ b/plugin.cc
@@ -571,8 +571,14 @@ bool get_sleigh_id(string &sleigh) {
          break;
       case PLFM_PIC:
          break;
-      case PLFM_PPC:
-         break;
+      case PLFM_PPC: {
+        // ABI name is set to "xbox" for X360 PPC executables
+        qstring abi;
+        if (get_abi_name(&abi) > 0 && abi.find("xbox") == 0) {
+          sleigh += ":64:VLE-32addr";
+        }
+        break;
+      }
       case PLFM_SPARC:
          break;
       case PLFM_MSP430:


### PR DESCRIPTION
This lets blc create the right sleigh ID for Ghidra to decompile Xbox360 code (at least I think it's the right sleigh ID - zeroKilo's X360 Ghidra loader [uses it](http://github.com/zeroKilo/XEXLoaderWV/blob/master/XEXLoaderWV/src/main/java/xexloaderwv/XEXLoaderWVLoader.java#L31), so I assume it's correct)

With this in place, it'll now decompile both Xbox360 EXEs and signed XEX files fine.

It sets this based on the ABI name being "xbox", my IDA XEX loader plugin [will set it to this ABI](https://github.com/emoose/idaxex/blob/master/idaloader.cpp#L159), and it seems IDA itself also sets this ABI when loading in an Xbox360 EXE file.

There does seem to be some issues with function parameters though, instead of using param_1 inside the decompiled output it'll use the return code from __savegprlr_xx(), which is weird since that shouldn't be returning anything...
(eg: https://i.imgur.com/OiSW6e8.png, the uses of iVar3 here should be using param_1 instead...)

The other parameters don't seem to be affected. Not sure if this is a Ghidra issue or maybe something to do with the integration... at least it's not too big of a problem, other than that everything else seems to work fine.

EDIT: If you want to test it out, here's a link to an old update XEX that used to be freely available on Microsoft's website: http://www.crusaders.no/~joker/old_web/lotto/default.xex
You'll need [my XEX loader](https://github.com/emoose/idaxex/releases) to load it into IDA though (Windows-only atm), sadly I'm not aware of any freely available X360 EXE files you could test with.